### PR TITLE
Calculs inverse: univers sans big bang, sans big crunch

### DIFF
--- a/Projet M1- Refonte/Calculs.html
+++ b/Projet M1- Refonte/Calculs.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <html>
-<head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 <meta charset="utf-8">
 <link rel="stylesheet" href="Css/Index.css">
@@ -23,34 +22,56 @@
 
 <script>
 	window.onload = function charg_params(){
+	var parameters = location.search.substring(1).split("&");
+    var temp = parameters[0].split("=");
+    T0 = unescape(temp[1]);
+    temp = parameters[1].split("=");
+    H0 = unescape(temp[1]);
+   	temp = parameters[2].split("=");
+	omegam0 = unescape(temp[1]);
+	temp = parameters[3].split("=");
+	omegalambda0 = unescape(temp[1]);
+	temp = parameters[4].split("=");
+	Or = unescape(temp[1]);
+	temp = parameters[5].split("=");
+	omegak0 = unescape(temp[1]);
+	temp = parameters[6].split("=");
+	k = unescape(temp[1]);
+	temp = parameters[7].split("=");
+	h = unescape(temp[1]);
+	temp = parameters[8].split("=");
+	G = unescape(temp[1]);
+	temp = parameters[9].split("=");
+	c = unescape(temp[1]);
+	temp = parameters[10].split("=");
+	typeannee = unescape(temp[1]);
+	temp = parameters[11].split("=");
+	nbr = unescape(temp[1]);
 	
-	// Recuperations des valeurs de la page simulation.
-	document.getElementById("T0_annexes").value = sessionStorage.getItem("T0");
-	document.getElementById("H0_annexes").value = sessionStorage.getItem("H0");
-	document.getElementById("omegam0_annexes").value = sessionStorage.getItem("Om");
-	document.getElementById("omegalambda0_annexes").value = sessionStorage.getItem("Ol");
-	document.getElementById("resultat_omegar0_annexes").value = sessionStorage.getItem("Or");
-	document.getElementById("resultat_omegak0_annexes").value = sessionStorage.getItem("Ok");
-	document.getElementById("k_p").value = sessionStorage.getItem("k");
-	document.getElementById("h_p").value = sessionStorage.getItem("h");
-	document.getElementById("G_p").value = sessionStorage.getItem("G");
-	document.getElementById("c_p").value = sessionStorage.getItem("c");
-	document.getElementById("typeannee").value = sessionStorage.getItem("type");
-	document.getElementById("nbr_precision").value = sessionStorage.getItem("nb");
+		
+	document.getElementById("T0_annexes").value = T0;
+	document.getElementById("H0_annexes").value = H0;
+	document.getElementById("omegam0_annexes").value = omegam0;
+	document.getElementById("omegalambda0_annexes").value = omegalambda0;
+	document.getElementById("resultat_omegar0_annexes").value = Or;
+	document.getElementById("resultat_omegak0_annexes").value = omegak0;
+	document.getElementById("k_p").value = k;
+	document.getElementById("h_p").value = h;
+	document.getElementById("G_p").value = G;
+	document.getElementById("c_p").value = c;
+	document.getElementById("typeannee").value = typeannee;
+	document.getElementById("nbr_precision").value = nbr;
 	
 	};
 </script>
-
-
+<head>
+<meta charset="UTF-8">
 <title>Calculs</title>
 </head>
 
 <body>
-<ul class="topnav">
-  <li><a class="active" href="#">Calculs Annexes</a></li>
-</ul>
-<div id="TOUT">
-<!--
+
+
 <ul class="topnav">
   <li><a href="index.html">Calculs Annexes</a></li>
   <li class="deroule">
@@ -68,7 +89,7 @@
 	</div>
   </li> 
 </ul>
--->
+
 <!-- Paramètres de base cachés -->
 
 	<input type="hidden" id="k_p" value="1.38064852e-23" ></input>
@@ -103,14 +124,12 @@
 </div>
 
 <div>
+	<label for="resultat_omegar0_annexes">&Omega;<sub>r0</sub> =</label>
 	<select id="resultat_omegar0_annexes" style="color:blue">
-		<option>Matière et Lambda</option>
-		<option>Matière, Lambda et RFC</option>
-		<option>Matière, Lambda, RFC et Neutrinos</option>
+		<option>Matter and Lambda</option>
+		<option>Matter, Lambda and RFC</option>
+		<option>Matter, Lambda, RFC and Neutrinos</option>
 	</select>
-	<br/>
-	<label for="resul_omegar0">&Omega;<sub>r0</sub> =</label>
-	<span id="resul_omegar0" style="color:blue;"></span>
 </div>
 
 <div>
@@ -226,34 +245,33 @@
 </div>
 	
  <br />
- 		<p><strong> Calculs Inverses</strong></p>
+
  		 <div class="desact_retour">
  		 	<label for="dm_racine_dm">d<sub>m</sub> =</label>
  		 	<input id="dm_racine_dm" value="0" maxlength="26" type="text"> (m)
- 		 	<label for="z_racine_dm">Z =</label>
+ 		 	<label for="z_racine_dm">Z =</label> 
  		 	<span id="z_racine_dm" style="color:blue"></span> <!--= <span id="dm1_pc" style="color:blue"></span> pc-->
  		 </div>
  		 <br/>
         <div class="desact_retour">
           <label for="t_racine_em">t<sub>emission</sub> =</label>
-          <input id="t_racine_em" value="0" maxlength="26" type="text"> (s)
+          <input id="t_racine_em" value="0" maxlength="26" type="text"> (annee)
           <label for="z_racine_t_em">   Z<sub>1</sub> =</label>
-          <span id="z_racine_t_em" style="color:blue"></span> <!--= <span id="dm1_pc" style="color:blue"></span> pc-->
+          <span id="z_racine_t_em" style="color:blue"></span> 
         </div>
         <br />
         <div class="desact_retour">
           <label for="t_racine_rec">t<sub>reception</sub> =</label>
-          <input id="t_racine_rec" value="0" maxlength="26" type="text"> (s)
+          <input id="t_racine_rec" value="0" maxlength="26" type="text"> (annee)
           <label for="z_racine_t_rec"> Z<sub>2</sub>=</label>
-          <span id="z_racine_t_rec" style="color:blue"></span> <!--= <span id="dm1_pc" style="color:blue"></span> pc-->
+          <span id="z_racine_t_rec" style="color:blue"></span> 
         </div>
         <div id="plus"><button type="button" onclick="inverse();">Calcul</button> 
+		<span id="z_lim" style="color:blue"></span> 
         </div>
 <br/>
 <span style="text-align: center;width:100%;"><input type="button" value="Retour" onClick="retour_simu()"/></span>
 <br/>
-</div>
 <p style="float:right"><script type="text/javascript" src="http://www.abcompteur.com/cpt/?code=1/54/17110/1/2&ID=43497119633"></script><noscript><a href="http://www.abcompteur.com/">ABCompteur : compteur gratuit</a></noscript> visites. </p>	
-
 </body>
 </html>

--- a/Projet M1- Refonte/js/Calculs_annexes/Adaptive_Simpson.js
+++ b/Projet M1- Refonte/js/Calculs_annexes/Adaptive_Simpson.js
@@ -1,23 +1,28 @@
 //formule utilis?e pour le calcul de l'age de l'univers
 function fonction_integrale(x, omegam0, omegalambda0, Or){
-	return (1.0/(1.0+x)) * Math.pow(Or*Math.pow(1.0+x, 4) + omegam0*Math.pow(1.0+x, 3) - (omegalambda0 + Or + omegam0 - 1.0)*Math.pow(1.0+x, 2) + omegalambda0, -1.0/2);
+	return (1.0/(1.0+x)) * Math.pow(Or*Math.pow(1.0+x, 4) + omegam0*Math.pow(1.0+x, 3) - (omegalambda0 + Or + omegam0 - 1.0)*Math.pow(1.0+x, 2) + omegalambda0, (-1.0/2));
 }
 
 //formule utilis?e pour le calcul de distance metrique
 function fonction_dm(x, omegam0, omegalambda0, Or){
-	return 1.0/Math.pow((Or*Math.pow((1.+x),4)+omegam0*Math.pow((1.+x),3)+(1-Or-omegam0-omegalambda0)*Math.pow((1+x),2)+omegalambda0),(1.0/2.0));
+	return 1.0/Math.pow((Or*Math.pow((1.0+x),4)+omegam0*Math.pow((1+x),3)+(1-Or-omegam0-omegalambda0)*Math.pow((1+x),2)+omegalambda0),(1.0/2.0));
 }
 
-// pour calculer les omegas pour une valeur de z
+// pour calculer les bornes de la région sur laquelle l'intégrale des fonctions ci-dessus est définie.
 function fonction_E(x,omegam0, omegalambda0, Or){
-	return (Or*Math.pow(1.0+x,4)+omegam0*Math.pow(1.0+x,3)+(1-omegam0-omegalambda0-Or)*Math.pow(1.0+x,2)+omegalambda0) ;}
+	return (Number(Or)*Math.pow((1+x),4) + Number(omegam0)*Math.pow((1+x),3) + (1-Number(omegam0)-Number(Or)-Number(omegalambda0))*Math.pow((1+x),2) + Number(omegalambda0));
+}
+
+function derive_fonction_E(x,omegam0, omegalambda0, Or){
+	return (Or*(Math.pow(1.0+x,2) + 8*x + 2) + 3 *omegam0*x + omegam0 -2*omegalambda0 + 2);
+}
+	
 
 
 
 //fonction de l'equation de simpson 
 function simpson(bornInf, bornSup, fonction, omegam0, omegalambda0, Or, eps){
 	whole = inetgrate_area_simpson(bornInf, bornSup, fonction, omegam0, omegalambda0, Or);
-
     return recursive_asr(bornInf, bornSup, fonction, omegam0, omegalambda0, Or, eps, whole);
 }
 
@@ -25,7 +30,6 @@ function inetgrate_area_simpson(bornInf, bornSup, fonction, omegam0, omegalambda
 
 	var centre = (bornInf+bornSup)/2.0;
 	var h3 = Math.abs(bornSup-bornInf)/6.0;
-	console.log(" fct" +fonction(bornSup,omegam0, omegalambda0, Or));
 	return h3*(fonction(bornInf,omegam0, omegalambda0, Or) + 4.0*fonction(centre,omegam0, omegalambda0, Or) + fonction(bornSup,omegam0, omegalambda0, Or));
 
 }

--- a/Projet M1- Refonte/js/Calculs_annexes/Calcu.js
+++ b/Projet M1- Refonte/js/Calculs_annexes/Calcu.js
@@ -44,7 +44,6 @@ function calcu(){
 		}else{
 		nbrjours = 365.2425;
 	}
-	
 	Eps = 0.00001;
 
 	//calcul de h0 par secondes et par gigaannees
@@ -54,22 +53,19 @@ function calcu(){
 	H0enannee = H0parsec*(3600*24*nbrjours);
 	H0engannee = H0enannee*Math.pow(10, 9);
 	
-	Affi_Or= document.getElementById("resul_omegar0");
+	
 	Or = 0;
-	Affi_Or.innerHTML = Or;
 	if (document.getElementById("resultat_omegar0_annexes").options[2].selected) {
 		sigma = (2*Math.pow(Math.PI, 5)*Math.pow(k, 4))/(15*Math.pow(h, 3)*Math.pow(c, 2));
 		rho_r = (4*sigma*Math.pow(t0, 4))/(Math.pow(c, 3));
 		Or =(8*Math.PI*G*rho_r)/(3*Math.pow(H0parsec, 2));
 		Or=1.68*Or;
 		Or = Or.toExponential();
-		Affi_Or.innerHTML = Or;
 		} else if (document.getElementById("resultat_omegar0_annexes").options[1].selected) {
 		sigma = (2*Math.pow(Math.PI, 5)*Math.pow(k, 4))/(15*Math.pow(h, 3)*Math.pow(c, 2));
 		rho_r = (4*sigma*Math.pow(t0, 4))/(Math.pow(c, 3));
 		Or =(8*Math.PI*G*rho_r)/(3*Math.pow(H0parsec, 2));
 		Or = Or.toExponential();
-		Affi_Or.innerHTML = Or;
 		} else {
 	}
 	
@@ -313,8 +309,8 @@ function calcu(){
 	
 	fin =new Date().getTime() - deb;
 	Chaine = "Le calcul a durer : " + fin + " millisecondes !";
-	//time_affiche.innerHTML = Chaine;
-	//time_affiche.style.display ="inline-block";
+	time_affiche.innerHTML = Chaine;
+	time_affiche.style.display ="inline-block";
 
 
 

--- a/Projet M1- Refonte/js/Calculs_annexes/bisection_root_finder.js
+++ b/Projet M1- Refonte/js/Calculs_annexes/bisection_root_finder.js
@@ -8,14 +8,14 @@ function inverse(){
 
 
 
+//#######################################     GET_ROOT_DM fonction suprême qui ordonne le calcul de "dm". récupère les paramètres de la page HTML Calculs
 
 
 function get_root_dm(){
 	//récupère les constants nécessaires pour les calculs
 	
 	au=149597870700;
-  c = Number(document.getElementById("c_p").value);
-  t0 = document.getElementById("T0_annexes").value;
+	c = Number(document.getElementById("c_p").value);
 	G = Number(document.getElementById("G_p").value);
 	h = Number(document.getElementById("h_p").value);
 	k = Number(document.getElementById("k_p").value);
@@ -24,9 +24,8 @@ function get_root_dm(){
 	omegalambda0 = Number(document.getElementById("omegalambda0_annexes").value);
 	omegalambda0 = omegalambda0.toExponential();
 	H0parsec = h0*1000/((au*(180*3600))/Math.PI*Math.pow(10, 6));
-	eps = 0.00001;
-	                                                              //tolérance d'érreur de l'intégral
-	//definition du type d'annee
+	eps = 0.00001;                                                              //tolérance d'érreur de l'intégral
+//definition du type d'annee
 	if(typeannee == "Sidérale"){
 		nbrjours = 365.256363051;
 		}else if(typeannee == "Julienne"){
@@ -37,7 +36,7 @@ function get_root_dm(){
 		nbrjours = 365.2425;
 	}
 	
-	Eps = 0.00001;
+	
 
 	//calcul de h0 par secondes et par gigaannees
 	au = 149597870700;
@@ -46,59 +45,76 @@ function get_root_dm(){
 	H0enannee = H0parsec*(3600*24*nbrjours);
 	H0engannee = H0enannee*Math.pow(10, 9);
 	
-
-	// Calcul et affichage de Omegar0
-	Affi_Or= document.getElementById("resul_omegar0");
+	
 	Or = 0;
-	Affi_Or.innerHTML = Or;
 	if (document.getElementById("resultat_omegar0_annexes").options[2].selected) {
-		console.log("denadn");
 		sigma = (2*Math.pow(Math.PI, 5)*Math.pow(k, 4))/(15*Math.pow(h, 3)*Math.pow(c, 2));
 		rho_r = (4*sigma*Math.pow(t0, 4))/(Math.pow(c, 3));
 		Or =(8*Math.PI*G*rho_r)/(3*Math.pow(H0parsec, 2));
 		Or=1.68*Or;
-		Or = Or.toExponential(3);
-		Affi_Or.innerHTML = Or;
+		Or = Or.toExponential();
 		} else if (document.getElementById("resultat_omegar0_annexes").options[1].selected) {
 		sigma = (2*Math.pow(Math.PI, 5)*Math.pow(k, 4))/(15*Math.pow(h, 3)*Math.pow(c, 2));
 		rho_r = (4*sigma*Math.pow(t0, 4))/(Math.pow(c, 3));
 		Or =(8*Math.PI*G*rho_r)/(3*Math.pow(H0parsec, 2));
-		Or = Or.toExponential(3);
-		Affi_Or.innerHTML = Or;
+		Or = Or.toExponential();
 		} else {
 	}
-	eps = 0.00001;                           
+	eps = 0.00001;      //tolérence d'erreur pour les intégrales                      
+	
 
 	dm = document.getElementById("dm_racine_dm").value;
 	z = bisection_method_dm(dm, omegam0, omegalambda0, Or, eps);
 	document.getElementById("z_racine_dm").innerHTML= z;
 	
+	
 }
+
+//#######################################     BISECTION_METHOD_DM prépare les variables et mène des vérifications nécessaires avant de lancer l'algorithme de dicothomie
 
 function bisection_method_dm (dm, omegam0, omegalambda0, Or, eps){
 	omegak0=(1-omegam0-omegalambda0-Or);
-	document.getElementById("resultat_omegak0_annexes").innerHTML = omegak0;
 	f_x = formule_z(omegak0);
 	za = 0;
-	zb = 1e8;
-	ex = 0.00001; //indicateur de tolérence d'erreur de l'interpolation/dichotomie
-
+	zb = 5e10;
+	ex = 0.0000001; //indicateur de tolérence d'erreur de l'interpolation/dichotomie
+	
 	dm_za = f_x(za, omegam0, omegalambda0, Or, eps); 
 	dm_zb = f_x(zb, omegam0, omegalambda0, Or, eps);
+	
+	//vérification des valeurs permisent
+	//cette variable possède 2 valeurs [nouveau_zb, contrainte] contrainte =0 ou 1. 0 pour absence de contrainte
+	reconditionneur = espacedefinie(omegam0, omegalambda0, Or); 
+	zb = Number(reconditionneur[0])-0.01;
+	alert("changed? " + zb);
+	contrainte = Number(reconditionneur[1]);
+	dm_za = f_x(za, omegam0, omegalambda0, Or, eps); 
+	dm_zb = f_x(zb, omegam0, omegalambda0, Or, eps);
+	
+	alert("dm_zb " + dm_zb);
 	if (Number(dm)===0){
 	  return 0;
 	}
 	
 	if (omegak0 <=0){
-	  limit = 0;
-		while (dm > dm_zb && limit<100){
-			zb = zb*10;
-			dm_zb = f_x(zb, omegam0, omegalambda0, Or, eps);
-			limit+=1;
-		}
-		if (limit===100){
-			  return true;
+		limit = 0;
+		if (contrainte ==0){
+			alert("you can't be serious");
+			while (dm > dm_zb && limit<100){
+				zb = zb*10;
+				dm_zb = f_x(zb, omegam0, omegalambda0, Or, eps);
+				limit+=1;
 			}
+			if (limit>=100){
+				return NaN;
+			}
+		}
+		//la fonction "fonction_dm" est monotone pour omegak <=0. Si dm est supérieur à dm_zb et que zb est fixé à une valeur maximal permise alors aucune solution ne peut être trouvé
+		if (dm>dm_zb){
+			alert("there's no way");
+			return NaN;
+		}
+		alert("it's getting better");
 		Z = dichotomie(za, zb, f_x, dm, ex);
 		return Z;
 	}
@@ -110,29 +126,30 @@ function bisection_method_dm (dm, omegam0, omegalambda0, Or, eps){
 			return NaN;  
 		}
 		integB = Math.sqrt( Math.abs(omegak0)) * simpson(0, zb, fonction_dm, omegam0, Number(omegalambda0), Number(Or), eps);
-		//dans ce cas sin(integrale) montone sur l'intervalle [za; zb] 
+		//dans cette situation, sin(integrale) est montone sur l'intervalle [za; zb] 
 		if (integB<Math.PI/2){
 			//on vérifie que dm n'est pas supérieur à dm_zb car dm_zb< A   ici l'integral du dm_zb est dans [0;PI/2]
 			if (dm > dm_zb){
 				return NaN;  
 			}
-			return dichotomie(za, zb, f_x, dm, ex);
+			return dichotomie(0, zb, f_x, dm, ex);
 		}
 		else if((integB>Math.PI/2) && (integB<Math.PI)){
-			z_Pi_div_2 = dichotomie (za, zb, Integral_dm, Math.PI/2, ex);
-			z_sol_1 = dichotomie (0, z_Pi_div_2, f_x, dm, ex);
+			z_Pi_div_2 = dichotomie(0, zb, Integral_dm, Math.PI/2, ex);
+			z_sol_1 = dichotomie(0, z_Pi_div_2, f_x, dm, ex);
 			if (dm>dm_zb){
-				z_sol_2 = dichotomie (z_Pi_div_2, zb, f_x, dm, ex);
-				return z_sol_1+", " + z_sol_2;
+				z_sol_2 = dichotomie(z_Pi_div_2, zb, f_x, dm, ex);
+				return (z_sol_1+", " + z_sol_2);
 			}
 			return z_sol_1;
 		}
 		else{
-			z_Pi_div_2 = dichotomie (za, zb, Integral_dm, Math.PI/2, ex);
-			z_Pi = dichotomie (za, zb, Integral_dm, Math.PI, ex);
-			z_sol_1 = dichotomie (0, z_Pi_div_1, f_x, dm, ex);
-			z_sol_2 = dichotomie (z_Pi_div_1, z_Pi, f_x, dm, ex);
-			return z_sol_1+", " + z_sol_2;
+			z_Pi_div_2 = Number(dichotomie(0, zb, Integral_dm, Math.PI/2, ex));
+			z_Pi = Number(dichotomie(0, 5e10, Integral_dm, Math.PI, ex));
+			z_sol_1 = dichotomie(0, z_Pi_div_2, f_x, dm, ex);
+			z_sol_2 = dichotomie(z_Pi_div_2, z_Pi, f_x, dm, ex);
+			z_f2 = z_sol_1+", " + z_sol_2;
+			return z_f2;
 		}
 	}
 }
@@ -140,18 +157,74 @@ function bisection_method_dm (dm, omegam0, omegalambda0, Or, eps){
 
 
 
-//												outil mathématique fondamental:   DICHOTOMIE  POUR "DM" 
+
+//########### ESPACE_DEFINIE fonction qui intervient pour vérifier si les paramètres omegas posent des contraintes à leur fonction associé.
+//                    si cette fonction signale la présence de régions de valeurs interdites pour les intégrales, elle désactive l'application de
+
+function espacedefinie(omegam0, omegalambda0, Or){
+	
+	//z_prime est la racine de la dérivé de E(x)  (E'(x)) sur [0, infini). c'est donce l'extremum (minimum) de E(x) sur [0, infini)
+	
+	//on vérifie à l'avance si E'(x) coupe l'axe des abscisses sur [0;infini)
+	D_prime_za = derive_fonction_E(za,omegam0, omegalambda0, Or);
+	alert(D_prime_za);
+	D_prime_zb = derive_fonction_E(zb,omegam0, omegalambda0, Or);
+	alert(D_prime_zb);
+	if (D_prime_za*D_prime_zb<0){
+		z_prime = Number(dichotomie(0, zb,derive_fonction_E,0,ex));
+		//si on a E(z_prime)>0 alors E(x) n'a pas de racines et donc aucune contrainte se manifèste pour les intégrales. On conserve zb
+		if (fonction_E(z_prime,omegam0, omegalambda0, Or)>0){
+			alert("this is zb" + zb);
+			res = [zb,0];    //0 va être un indicateur qu'on utilisera plus tard qui confirme l'absence des contraintes possibles.
+			return res;
+		}
+	
+		//si on a E(z_prime)=0 alors E(x) possède une racine. Une contrainte se manifèste, zb->z_prime les intégrales sont définit sur [0, z_prime)
+		else if(fonction_E(z_prime,omegam0, omegalambda0, Or)==0){
+			res = [z_prime, 1]; //1 va confirmer la présence de contraintes
+			document.getElementById("z_lim").innerHTML= z_prime;
+			return res;
+		}
+	
+		////si on a E(z_prime)<0 alors E(x) possède 2 racines. On prend la première z_pr. intégrales sont définit sur [0, z_pr)
+		else{
+			z_pr = Number(dichotomie(0, z_prime,fonction_E,0,ex));
+			res = [z_pr,1];
+			document.getElementById("z_lim").innerHTML= z_pr;
+			return res;
+		}
+	}
+	
+	//si E'(x) ne coupe pas l'axe des abscisses sur [0;infini) alors on conserve la valeur de zb et on indique l'absence de contraintes.
+	else{
+		return res = [zb,0];
+	}
+}
+
+
+
+
+
+
+
+//########### DICHOTOMIE     outil mathématique fondamental:   DICHOTOMIE  POUR "T"   
+
 function dichotomie(BornInf, BornSup, fonction, cible, ex){
 	za = BornInf;
 	zb = BornSup;
 	dm_za = fonction(za, omegam0, omegalambda0, Or, eps); 
 	dm_zb = fonction(zb, omegam0, omegalambda0, Or, eps);
+	
+	max_iterations = 500;
+	j = 0;
 	while (true){
 			zc = (za+zb)/2.0;
 			
 			dm_zc = fonction(zc, omegam0, omegalambda0, Or, eps);
+			//alert("za : " + za + " dm_za: " + dm_za + " zb: " + zb + " dm_zb: " + dm_zb + " zc: " + zc+ " ex: " + ex); 
 			if (((zb-za)/2)<ex){
 				if ((zc/ex) < 3){
+					
 					ex = ex*1e-5;
 				}
 				else{
@@ -159,13 +232,19 @@ function dichotomie(BornInf, BornSup, fonction, cible, ex){
 					return zc;
 				}
 			}
+			else if(isNaN(dm_zc)){
+				return NaN;
+			}
+				
 			else if ((dm_zc-cible)*(dm_zb-cible)< 0){
 				za = zc;
 				dm_za = dm_zc;
+				j+=1;
 			}
 			else{
 				zb = zc;
 				dm_zb = dm_zc;
+				j+=1;
 			}
 		}
 }
@@ -174,7 +253,8 @@ function dichotomie(BornInf, BornSup, fonction, cible, ex){
 //fonction définit du produit de  l'intégral de la fonction "fonction_dm" avec abs(omegak0)^0.5   Ceci sert à trouver le z correspondant a pi/2 ou pi pour cette fonction
 
 function Integral_dm(bornSup, omegam0, omegalambda0, Or, eps){
-	 integ = Math.sqrt( Math.abs(omegak0)) * simpson(0, bornSup, fonction_dm, omegam0, Number(omegalambda0), Number(Or), eps);
+	omegak0=(1-omegam0-omegalambda0-Or);
+	return Math.sqrt( Math.abs(omegak0)) * simpson(0, bornSup, fonction_dm, omegam0, Number(omegalambda0), Number(Or), eps);
 }
 
 
@@ -199,9 +279,8 @@ function Sk_x(bornSup, omegam0, omegalambda0, Or, eps){
   }
 
 function Sk_sinh_x(bornSup, omegam0, omegalambda0, Or, eps){
-	
-    integ = Math.sqrt( Math.abs(omegak0)) * simpson(0, bornSup, fonction_dm, omegam0, Number(omegalambda0), Number(Or), eps);
-    return (c/(H0parsec*Math.sqrt( Math.abs(omegak0) ))) * Math.sinh(integ);
+    integ = Math.sqrt( Math.abs(Number(omegak0))) * simpson(0, Number(bornSup), fonction_dm, Number(omegam0), Number(omegalambda0), Number(Or), eps);
+    return (c/(H0parsec*Math.sqrt( Math.abs(Number(omegak0)) ))) * Math.sinh(integ);
   }
 
   
@@ -243,26 +322,34 @@ function dichotomie_t(BornInf, BornSup, cible, ext, type){
 	
 	t_za = f_za(za, omegam0, omegalambda0, Or, eps); 
 	t_zb = f_zb(zb, omegam0, omegalambda0, Or, eps);
+	
+	max_iterations_t = 500;
+	i = 0;
 	while (true){
 			zc = (za+zb)/2.0;
 			f_zc = formule_t(zc, omegam0, omegalambda0, Or, type);
 			t_zc = f_zc(zc, omegam0, omegalambda0, Or, eps);
 			if (((zb-za)/2)<ext){
-				if ((zc/ext)<10){
-					ext = ext*1e-5;
+				if ((zc/ext)<100){
+					ext = ext*1e-5; //si Z est petit, la tolérence d'erreur de la dichotomie doit être réduit.
 				}
 				else{
 					zc = zc.toExponential(3);
 					return zc;
 				}
 			}
+			else if(isNaN(t_zc)){
+				return NaN;
+			}
 			else if ((t_zc-cible)*(t_zb-cible)< 0){
 				za = zc;
 				t_za = t_zc;
+				i+=1;
 			}
 			else{
 				zb = zc;
 				t_zb = t_zc;
+				i+=1;
 			}
 		}
 }
@@ -277,7 +364,6 @@ function dichotomie_t(BornInf, BornSup, cible, ext, type){
 function get_root_t(){
 	au=149597870700;
 	c = Number(document.getElementById("c_p").value);
-	t0 = document.getElementById("T0_annexes").value;
 	G = Number(document.getElementById("G_p").value);
 	h = Number(document.getElementById("h_p").value);
 	k = Number(document.getElementById("k_p").value);
@@ -286,7 +372,7 @@ function get_root_t(){
 	omegalambda0 = Number(document.getElementById("omegalambda0_annexes").value);
 	omegalambda0 = omegalambda0.toExponential();
 	H0parsec = h0*1000/((au*(180*3600))/Math.PI*Math.pow(10, 6));
-	eps = 0.0000001;                                                              //tolérance d'érreur de l'intégral
+	eps = 0.0001;                                                              //tolérance d'érreur de l'intégral
 	//definition du type d'annee
 	if(typeannee == "Sidérale"){
 		nbrjours = 365.256363051;
@@ -306,31 +392,25 @@ function get_root_t(){
 	H0enannee = H0parsec*(3600*24*nbrjours);
 	H0engannee = H0enannee*Math.pow(10, 9);
 	
-	
-	Affi_Or= document.getElementById("resul_omegar0");
 	Or = 0;
-	Affi_Or.innerHTML = Or;
 	if (document.getElementById("resultat_omegar0_annexes").options[2].selected) {
 		sigma = (2*Math.pow(Math.PI, 5)*Math.pow(k, 4))/(15*Math.pow(h, 3)*Math.pow(c, 2));
 		rho_r = (4*sigma*Math.pow(t0, 4))/(Math.pow(c, 3));
 		Or =(8*Math.PI*G*rho_r)/(3*Math.pow(H0parsec, 2));
 		Or=1.68*Or;
-		Or = Or.toExponential(3);
-		Affi_Or.innerHTML = Or;
+		Or = Or.toExponential();
 		} else if (document.getElementById("resultat_omegar0_annexes").options[1].selected) {
 		sigma = (2*Math.pow(Math.PI, 5)*Math.pow(k, 4))/(15*Math.pow(h, 3)*Math.pow(c, 2));
 		rho_r = (4*sigma*Math.pow(t0, 4))/(Math.pow(c, 3));
 		Or =(8*Math.PI*G*rho_r)/(3*Math.pow(H0parsec, 2));
-		Or = Or.toExponential(3);
-		Affi_Or.innerHTML = Or;
+		Or = Or.toExponential();
 		} else {
 	}
-	
-	t_em = (document.getElementById("t_racine_em").value)*H0parsec;
+	t_em = (document.getElementById("t_racine_em").value)*H0enannee;
 	z_em = bisection_method_t(t_em, omegam0, omegalambda0, Or, eps, 0);
 	document.getElementById("z_racine_t_em").innerHTML= z_em;
 	
-	t_rec = (document.getElementById("t_racine_rec").value)*H0parsec;
+	t_rec = (document.getElementById("t_racine_rec").value)*H0enannee;
 	z_rec = bisection_method_t(t_rec, omegam0, omegalambda0, Or, eps, 1);
 	document.getElementById("z_racine_t_rec").innerHTML= z_rec;
 }
@@ -344,10 +424,9 @@ function get_root_t(){
 
 function bisection_method_t (t, omegam0, omegalambda0, Or, eps, type){
 	omegak0=(1-omegam0-omegalambda0-Or);
-	document.getElementById("resultat_omegak0_annexes").innerHTML = omegak0;
 	var za = 0;
 	var zb = 5e6; //valeur par default
-	ext = 0.00000000001; //indicateur de tolérence d'erreur dichotomie temporelle
+	ext = 0.00001; //indicateur de tolérence d'erreur dichotomie temporelle
 	
 	f_x_zb = formule_t(zb, omegam0, omegalambda0, Or, eps);
 	t_zb = f_x_zb(zb, omegam0, omegalambda0, Or, eps);
@@ -355,19 +434,64 @@ function bisection_method_t (t, omegam0, omegalambda0, Or, eps, type){
 	f_x_za = formule_t(za, omegam0, omegalambda0, Or, eps);
 	t_za = f_x_za(za, omegam0, omegalambda0, Or, eps);
 	
-	//uncalculable signale si le calcul inverse est impossible. Sa fonction associé regulator ajuste l'intervalle où la solution peut se trouver
+	reconditionneur_t  = espace_definie(omegam0, omegalambda0, Or);
+	contrainte_t = Number(reconditionneur_t[1]);
 	
-	uncalculable = regulator(za, zb, t, omegam0, omegalambda0, Or);
-	if (isNaN(uncalculable[0]) || isNaN(uncalculable[1])){
-		return NaN;
+	//aucune contrainte, zb est donné la possibilité de prendre n'importe quelle valeur
+	if (contrainte_t==0){
+		//Les integrales convergent. Ici uncalculable signale si le calcul inverse est impossible. Sa fonction associé regulator ajuste 
+		//l'intervalle où la solution peut se trouver
+		uncalculable = regulator(za, zb, t, omegam0, omegalambda0, Or);
+		if (isNaN(uncalculable[0]) || isNaN(uncalculable[1])){
+			return NaN;
+		}
+		za = uncalculable[0];
+		zb = uncalculable[1];
 	}
-	za = uncalculable[0];
-	zb = uncalculable[1];
+	else{
+		zb = reconditionneur_t[0];
+	}
+	
 	return dichotomie_t(za, zb, t, ext, type);
 }
 
 
 
+
+//########### ESPACE_DEFINIE fonction qui intervient pour vérifier si les paramètres omegas posent des contraintes à leur fonction associé.
+//                    si cette fonction signale la présence de régions de valeurs interdites pour les intégrales, elle désactive l'application de
+
+function espace_definie(omegam0, omegalambda0, Or){
+
+	D_prime_za = derive_fonction_E(za,omegam0, omegalambda0, Or);
+	D_prime_zb = derive_fonction_E(zb,omegam0, omegalambda0, Or);
+	if (D_prime_za*D_prime_zb<0){
+		//z_prime est la racine de la dérivé de E(x)  (E'(x)) sur [0, infini). c'est donce l'extremum (minimum) de E(x) sur [0, infini)
+		z_prime = Number(dichotomie(0, zb,derive_fonction_E,0,ex))-0.001;
+	
+		//si on a E(z_prime)>0 alors E(x) n'a pas de racines et donc aucune contrainte se manifèste pour les intégrales. On conserve zb
+		if (fonction_E(z_prime,omegam0, omegalambda0, Or)>0){
+			res = [zb,0];    //0 va être un indicateur qu'on utilisera plus tard qui confirme l'absence des contraintes possibles.
+			return res;
+		}
+	
+		//si on a E(z_prime)=0 alors E(x) possède une racine. Une contrainte se manifèste, zb->z_prime les intégrales sont définit sur [0, z_prime)
+		else if(fonction_E(z_prime,omegam0, omegalambda0, Or)==0){
+			res = [z_prime, 1]; //1 va confirmer la présence de contraintes
+			return res;
+		}
+	
+		////si on a E(z_prime)<0 alors E(x) possède 2 racines. On prend la première z_pr. intégrales sont définit sur [0, z_pr)
+		else{
+			z_pr = Number(dichotomie(0, z_prime,fonction_E,0,ex))-0.001;
+			res = [z_pr,1];
+			return res;
+		}
+	}
+	else{
+		return res = [zb,0];
+	}
+}
 
 //#########################################################         FORMULE_T  choisit la fonction correspondante aux paramètres omegas et z récupérés de la page html
 
@@ -390,11 +514,8 @@ function formule_t(z, omegam0, omegalambda0, Or, type){
 		
 		
 		if(z <= 5e6){  
-			if(omegalambda0 >= Olambdalim && type===1) {
-				return Or_rec_z_inf_omlambda_sup;
-			}
-			else if(omegalambda0 >= Olambdalim && type===0){
-				return Or_emi_z_inf_omlambda_sup;
+			if(omegalambda0 >= Olambdalim){
+				return Or_z_inf_omlambda_sup;
 			}
 			else{
 				return Or_z_inf_omlambda_inf;
@@ -430,8 +551,8 @@ function formule_t(z, omegam0, omegalambda0, Or, type){
 		}
 	}
 					  
-	if(Or === 0 && omegam0=== 0 && omegak0 === 0){  
-	  return T_Or_omegam0_omegak0;
+	if(Or === 0 && omegam0=== 0 && omegak0 === 0){
+		return T_Or_omegam0_omegak0;
 	}		
 }
 
@@ -444,6 +565,7 @@ function formule_t(z, omegam0, omegalambda0, Or, type){
 function regulator(za, zb, t, omegam0, omegalambda0, Or){
 	//la fonction associé à ces paramètres est monotone décroissante za<zb --- t_za>t_zb
 	if(Or === 0 && omegam0 !== 0){ 
+		//valeur maximale: t_za. Valeur non physique: t =<0
 		if (t>t_za || t===0 || t<0){
 			  new_z = [NaN,NaN];
 			  
@@ -453,11 +575,12 @@ function regulator(za, zb, t, omegam0, omegalambda0, Or){
 		else{
 		  limit =0;
 		  while (t< t_zb && t!==0 && limit<100){
-			  zb = zb*100;
+			zb = zb*100;
 		  	f_x_zb = formule_t(zb, omegam0, omegalambda0, Or, eps);
 		  	t_zb = f_x_zb(zb, omegam0, omegalambda0, Or, eps);
 		  	limit+=1;
 		  }
+		  //ceci démontre l'impossibilité de calculer la solution dû à la convergence de l'intégrale
 		  if (limit===100){
 		  	  new_z = [NaN,NaN];
 		      return new_z;
@@ -538,8 +661,24 @@ function regulator(za, zb, t, omegam0, omegalambda0, Or){
 		
 		//la fonction associé à ces paramètres est monotone croissante za<zb --- t_za<t_zb
 		if(omegalambda0 >= Olambdalim){
-		  new_z = [za,zb];
-		  return new_z;                    //<----------------------------------à VOIR
+			if (t<t_za || t===0 || t<0){
+				new_z = [NaN,NaN];
+				return new_z;
+			}
+			limit = 0;
+			//regulation de l'intervalle
+			while (t > t_zb && t!==0 &&limit<100){
+				zb = zb*10;
+				f_x_zb = formule_t(zb, omegam0, omegalambda0, Or, eps);
+				t_zb = f_x_zb(zb, omegam0, omegalambda0, Or, eps);
+				limit+=1;
+			}
+			if (limit===100){
+				new_z = [NaN,NaN];
+				return new_z;
+			}
+			new_z = [za,zb];
+			return new_z;                  
 		}
 		
 		
@@ -578,11 +717,8 @@ function regulator(za, zb, t, omegam0, omegalambda0, Or){
 
 //liste des formes de la fonction pour les calculs de temps
 
-function Or_rec_z_inf_omlambda_sup(z, omegam0, omegalambda0, Or, eps){
-	return simpson(1/(1+z), 1, fonction_integrale,Number(Or), omegam0,Number(omegak0),Number(omegalambda0),eps) ;
-}
 
-function Or_emi_z_inf_omlambda_sup(z, omegam0, omegalambda0, Or, eps){
+function Or_z_inf_omlambda_sup(z, omegam0, omegalambda0, Or, eps){
 	return simpson(0, z, fonction_integrale, omegam0, Number(omegalambda0), Number(Or), eps);
 }
 
@@ -591,7 +727,7 @@ function Or_z_inf_omlambda_inf(z, omegam0, omegalambda0, Or, eps){
 }
 
 function Or_z_sup_omlambda_sup(z, omegam0, omegalambda0, Or, eps){
-	return tempsReception = simpson(0, 5e6, fonction_integrale, omegam0, Number(omegalambda0), Number(Or), eps)+0.5*(1/(Math.pow(Or, 1/2)))*(1/Math.pow(5e6,2)-1/Math.pow(z2,2));
+	return simpson(0, 5e6, fonction_integrale, omegam0, Number(omegalambda0), Number(Or), eps)+0.5*(1/(Math.pow(Or, 1/2)))*(1/Math.pow(5e6,2)-1/Math.pow(z2,2));
 }
 
 function Or_z_sup_omlambda_inf(z, omegam0, omegalambda0, Or, eps){
@@ -619,6 +755,5 @@ function T_Or_omegam0_z_sup(z, omegam0, omegalambda0, Or, eps){
 }
 
 function T_Or_omegam0_omegak0(z, omegam0, omegalambda0, Or, eps){
-  return Math.log(1+z)/Math.pow(Number(omegalambda0), 1/2);
+	return Math.log(1+z)/Math.pow(Number(omegalambda0), 1/2);
 }
-


### PR DESCRIPTION
-La fonction "espacedefinie" cherche les bordures de l'espace sur
laquelle les intégrales sont définits.
Des cas particuliers émèregent de la région des univers sans big bang et
crunch. (l'algorithme n'est pas encore complet pour traiter ces cas).
-La limite de zb apparaît à côté du boutton calcul inverse seulement
lorsque celle ci est activé par la souris.
-Correction du bug dans "get_root_dm()"
-rajout des deux fonctions E(x) et E'(x). Elles permettent de lancer la
recherche des régions permisent pour les intégrales.